### PR TITLE
Swap order of cwlVersion and class

### DIFF
--- a/cwlformat/keyorder.yml
+++ b/cwlformat/keyorder.yml
@@ -43,8 +43,8 @@ generic-ordering:
 
 
 CommandLineTool:
-  - class
   - cwlVersion
+  - class
   - label
   - doc
   - $namespaces
@@ -62,8 +62,8 @@ CommandLineTool:
 
 
 ExpressionTool:
-  - class
   - cwlVersion
+  - class
   - label
   - doc
   - requirements
@@ -75,8 +75,8 @@ ExpressionTool:
 
 
 Workflow:
-  - class
   - cwlVersion
+  - class
   - label
   - doc
   - $namespaces


### PR DESCRIPTION
As per https://github.com/rabix/cwl-format/issues/15, swap order of cwlVersion and class to make `cwl-format` consistent with recommended best practice.